### PR TITLE
Update array key to match terraform.tfvars.example

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -110,7 +110,7 @@ locals {
     nsg_ids      = module.network.nsg_ids
     subnet_id    = lookup(module.network.subnet_ids, "masters")
     subnet_label = module.network.master_subnet_dns_label
-    subnet_mask  = cidrnetmask(cidrsubnet(var.vcn_cidr, var.newbits["master"], var.netnum["master"]))
+    subnet_mask  = cidrnetmask(cidrsubnet(var.vcn_cidr, var.newbits["masters"], var.netnum["masters"]))
   }
 
   # operator module parameters

--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -5,7 +5,7 @@ locals {
   # subnet cidrs - used by subnets
   bastion_subnet  = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["bastion"], var.olcne_network_vcn.netnum["bastion"])
   int_lb_subnet   = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["lb"], var.olcne_network_vcn.netnum["int_lb"])
-  master_subnet   = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["master"], var.olcne_network_vcn.netnum["master"])
+  master_subnet   = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["masters"], var.olcne_network_vcn.netnum["masters"])
   operator_subnet = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["operator"], var.olcne_network_vcn.netnum["operator"])
   pub_lb_subnet   = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["lb"], var.olcne_network_vcn.netnum["pub_lb"])
   worker_subnet   = cidrsubnet(var.olcne_network_vcn.vcn_cidr, var.olcne_network_vcn.newbits["workers"], var.olcne_network_vcn.netnum["workers"])


### PR DESCRIPTION
As described in #1 there is a mismatch between values in terraform.tfvars.example and those used by the code. 
Signed-off-by: Mark Cram <mark.cram@oracle.com>