### PR TITLE
Use Oracle Linux helm rpm

### DIFF
--- a/modules/operator/scripts/install_helm.template.sh
+++ b/modules/operator/scripts/install_helm.template.sh
@@ -4,16 +4,7 @@
 
 echo 'installing helm'
 
-wget https://get.helm.sh/helm-v${helm_version}-linux-amd64.tar.gz 2> /dev/null
-
-
-tar zxvf helm-v${helm_version}-linux-amd64.tar.gz 2> /dev/null
-
-sudo mv linux-amd64/helm /usr/local/bin 2> /dev/null
-
-rm -f helm-v${helm_version}-linux-amd64.tar.gz 2> /dev/null
-
-rm -rf linux-amd64 2> /dev/null
+sudo yum install -y helm-${helm_version} 2> /dev/null
 
 helm repo add stable https://kubernetes-charts.storage.googleapis.com 2> /dev/null
 


### PR DESCRIPTION
The operator node installs helm from upstream, amend to use helm shipped by Oracle as an RPM
Signed-off-by: Mark Cram <mark.cram@oracle.com>