### PR TITLE
Allow the use of HTTPS terminated inside the cluster

### DIFF
--- a/modules/loadbalancer/loadbalancer.tf
+++ b/modules/loadbalancer/loadbalancer.tf
@@ -41,5 +41,5 @@ resource "oci_load_balancer_listener" "https_listener" {
   name                     = "https"
   default_backend_set_name = oci_load_balancer_backend_set.ingress_controller[1].name
   port                     = 443
-  protocol                 = "HTTP"
+  protocol                 = "TCP"
 }


### PR DESCRIPTION
Currently HTTPS will not work as the OCI load balancer uses HTTP to talk to the TLS terminated nginx-ingress. This change passes the connection through for termination inside the Kubernetes cluster.

Signed-off-by: Mark Cram <mark.cram@oracle.com>