### PR TITLE
Use defined registry for nginx image 

### DIFF
--- a/modules/olcne/scripts/create_kubernetes_module.template.sh
+++ b/modules/olcne/scripts/create_kubernetes_module.template.sh
@@ -8,6 +8,7 @@ echo "Creating Kubernetes module ${cluster_name} in environment ${environment}"
 olcnectl --api-server 127.0.0.1:8091 module create --environment-name "${environment}" \
   --module kubernetes --name "${cluster_name}" \
   --container-registry "${container_registry}"/olcne \
+  --nginx-image "${container_registry}"/olcne/nginx:1.12.2 \
   --virtual-ip "${master_vip}" \
   --master-nodes "${master_nodes_addresses}" \
   --worker-nodes "${worker_nodes_addresses}" 2> /dev/null


### PR DESCRIPTION
The Kubernetes module will use container-registry.oracle.com if you don't specify a path to the nginx image. Use the existing `container_registry` value as a source for the nginx image.
Signed-off-by: Mark Cram <mark.cram@oracle.com>