### PR TITLE
Deploy OCI loadbalancer for Istio

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ module "worker" {
   timezone            = var.worker_timezone
 
   # olcne public load balancer to attach to worker pool
-  oci_loadbalancer_id = module.loadbalancer.pub_lb_id
+  nginx_oci_loadbalancer_id = module.loadbalancer.pub_lb_id
 }
 
 module "loadbalancer" {

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ module "worker" {
 
   # olcne public load balancer to attach to worker pool
   nginx_oci_loadbalancer_id = module.loadbalancer.pub_lb_id
+  istio_oci_loadbalancer_id = module.loadbalancer.istio_lb_id
 }
 
 module "loadbalancer" {

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ module "worker" {
   timezone            = var.worker_timezone
 
   # olcne public load balancer to attach to worker pool
-  nginx_oci_loadbalancer_id = module.loadbalancer.pub_lb_id
+  nginx_oci_loadbalancer_id = module.loadbalancer.nginx_lb_id
   istio_oci_loadbalancer_id = module.loadbalancer.istio_lb_id
 }
 
@@ -148,5 +148,5 @@ module "olcne" {
 
   helm_version = var.helm_version
 
-  loadbalancer_ip_address = module.loadbalancer.pub_lb_ip
+  loadbalancer_ip_address = module.loadbalancer.nginx_lb_ip
 }

--- a/modules/loadbalancer/loadbalancer-istio.tf
+++ b/modules/loadbalancer/loadbalancer-istio.tf
@@ -1,0 +1,41 @@
+# Copyright 2020, Oracle Corporation and/or affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+resource "oci_load_balancer_load_balancer" "istio_lb" {
+  compartment_id = var.compartment_id
+  display_name   = "${var.label_prefix}-istio_lb"
+  shape          = var.pub_lb_shape
+  subnet_ids     = [var.pub_lb_subnet_id]
+
+  is_private                 = false
+  network_security_group_ids = [lookup(var.nsg_ids, "pub_lb")]
+}
+
+resource "oci_load_balancer_backend_set" "istio_ingress_controller" {
+  load_balancer_id = oci_load_balancer_load_balancer.istio_lb.id
+  name             = "${var.label_prefix}-ic-${local.istio_ingress_ports[count.index]}"
+
+  health_checker {
+    protocol = "TCP"
+  }
+
+  policy = "ROUND_ROBIN"
+
+  count = length(local.istio_ingress_ports)
+}
+
+resource "oci_load_balancer_listener" "istio_http_listener" {
+  load_balancer_id         = oci_load_balancer_load_balancer.istio_lb.id
+  name                     = "http"
+  default_backend_set_name = oci_load_balancer_backend_set.istio_ingress_controller[0].name
+  port                     = 80
+  protocol                 = "TCP"
+}
+
+resource "oci_load_balancer_listener" "istio_https_listener" {
+  load_balancer_id         = oci_load_balancer_load_balancer.istio_lb.id
+  name                     = "https"
+  default_backend_set_name = oci_load_balancer_backend_set.istio_ingress_controller[1].name
+  port                     = 443
+  protocol                 = "TCP"
+}

--- a/modules/loadbalancer/loadbalancer-istio.tf
+++ b/modules/loadbalancer/loadbalancer-istio.tf
@@ -16,7 +16,9 @@ resource "oci_load_balancer_backend_set" "istio_ingress_controller" {
   name             = "${var.label_prefix}-ic-${local.istio_ingress_ports[count.index]}"
 
   health_checker {
-    protocol = "TCP"
+    interval_ms  = 10000
+    protocol     = "TCP"
+    port         = 31380
   }
 
   policy = "ROUND_ROBIN"

--- a/modules/loadbalancer/loadbalancer.tf
+++ b/modules/loadbalancer/loadbalancer.tf
@@ -13,7 +13,7 @@ resource "oci_load_balancer_load_balancer" "pub_lb" {
 
 resource "oci_load_balancer_backend_set" "ingress_controller" {
   load_balancer_id = oci_load_balancer_load_balancer.pub_lb.id
-  name             = "${var.label_prefix}-ic-${local.ingress_ports[count.index]}"
+  name             = "${var.label_prefix}-ic-${local.nginx_ingress_ports[count.index]}"
 
   health_checker {
     interval_ms         = 10000
@@ -25,7 +25,7 @@ resource "oci_load_balancer_backend_set" "ingress_controller" {
 
   policy = "ROUND_ROBIN"
 
-  count = length(local.ingress_ports)
+  count = length(local.nginx_ingress_ports)
 }
 
 resource "oci_load_balancer_listener" "http_listener" {

--- a/modules/loadbalancer/locals.tf
+++ b/modules/loadbalancer/locals.tf
@@ -3,4 +3,5 @@
 
 locals {
   nginx_ingress_ports = [30080, 30443]
+  istio_ingress_ports = [31380, 31390]
 }

--- a/modules/loadbalancer/locals.tf
+++ b/modules/loadbalancer/locals.tf
@@ -2,5 +2,5 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  ingress_ports = [30080, 30443]
+  nginx_ingress_ports = [30080, 30443]
 }

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -1,11 +1,11 @@
 # Copyright 2020, Oracle Corporation and/or affiliates.  
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-output "pub_lb_id" {
+output "nginx_lb_id" {
   value = oci_load_balancer_load_balancer.pub_lb.id
 }
 
-output "pub_lb_ip" {
+output "nginx_lb_ip" {
   value = oci_load_balancer_load_balancer.pub_lb.ip_address_details[0].ip_address
 }
 

--- a/modules/loadbalancer/outputs.tf
+++ b/modules/loadbalancer/outputs.tf
@@ -8,3 +8,11 @@ output "pub_lb_id" {
 output "pub_lb_ip" {
   value = oci_load_balancer_load_balancer.pub_lb.ip_address_details[0].ip_address
 }
+
+output "istio_lb_id" {
+  value = oci_load_balancer_load_balancer.istio_lb.id
+}
+
+output "istio_lb_ip" {
+  value = oci_load_balancer_load_balancer.istio_lb.ip_address_details[0].ip_address
+}

--- a/modules/worker/compute.tf
+++ b/modules/worker/compute.tf
@@ -71,6 +71,18 @@ resource "oci_core_instance_pool" "worker" {
       vnic_selection   = "PrimaryVnic"
     }
   }
+  dynamic "load_balancers" {
+
+    iterator = port_iterator
+    for_each = local.istio_ingress_ports
+
+    content {
+      backend_set_name = "${var.label_prefix}-ic-${port_iterator.value}"
+      load_balancer_id = var.istio_oci_loadbalancer_id
+      port             = port_iterator.value
+      vnic_selection   = "PrimaryVnic"
+    }
+  }
 
   lifecycle {
     ignore_changes = [display_name]

--- a/modules/worker/compute.tf
+++ b/modules/worker/compute.tf
@@ -62,7 +62,7 @@ resource "oci_core_instance_pool" "worker" {
   dynamic "load_balancers" {
 
     iterator = port_iterator
-    for_each = local.ingress_ports
+    for_each = local.nginx_ingress_ports
 
     content {
       backend_set_name = "${var.label_prefix}-ic-${port_iterator.value}"

--- a/modules/worker/compute.tf
+++ b/modules/worker/compute.tf
@@ -60,26 +60,12 @@ resource "oci_core_instance_pool" "worker" {
   }
 
   dynamic "load_balancers" {
-
-    iterator = port_iterator
-    for_each = local.nginx_ingress_ports
+    for_each = local.ingress
 
     content {
-      backend_set_name = "${var.label_prefix}-ic-${port_iterator.value}"
-      load_balancer_id = var.nginx_oci_loadbalancer_id
-      port             = port_iterator.value
-      vnic_selection   = "PrimaryVnic"
-    }
-  }
-  dynamic "load_balancers" {
-
-    iterator = port_iterator
-    for_each = local.istio_ingress_ports
-
-    content {
-      backend_set_name = "${var.label_prefix}-ic-${port_iterator.value}"
-      load_balancer_id = var.istio_oci_loadbalancer_id
-      port             = port_iterator.value
+      backend_set_name = "${var.label_prefix}-ic-${load_balancers.value["port"]}"
+      load_balancer_id = load_balancers.value["loadbalancer"]
+      port             = load_balancers.value["port"]
       vnic_selection   = "PrimaryVnic"
     }
   }

--- a/modules/worker/compute.tf
+++ b/modules/worker/compute.tf
@@ -66,7 +66,7 @@ resource "oci_core_instance_pool" "worker" {
 
     content {
       backend_set_name = "${var.label_prefix}-ic-${port_iterator.value}"
-      load_balancer_id = var.oci_loadbalancer_id
+      load_balancer_id = var.nginx_oci_loadbalancer_id
       port             = port_iterator.value
       vnic_selection   = "PrimaryVnic"
     }

--- a/modules/worker/locals.tf
+++ b/modules/worker/locals.tf
@@ -25,4 +25,5 @@ locals {
   ]
 
   nginx_ingress_ports = [30080, 30443]
+  istio_ingress_ports = [31380, 31390]
 }

--- a/modules/worker/locals.tf
+++ b/modules/worker/locals.tf
@@ -24,5 +24,5 @@ locals {
     vnic.private_ip_address
   ]
 
-  ingress_ports = [30080, 30443]
+  nginx_ingress_ports = [30080, 30443]
 }

--- a/modules/worker/locals.tf
+++ b/modules/worker/locals.tf
@@ -24,6 +24,10 @@ locals {
     vnic.private_ip_address
   ]
 
-  nginx_ingress_ports = [30080, 30443]
-  istio_ingress_ports = [31380, 31390]
+  ingress = [
+    { loadbalancer = var.nginx_oci_loadbalancer_id, port = 30080},
+    { loadbalancer = var.nginx_oci_loadbalancer_id, port = 30443},
+    { loadbalancer = var.istio_oci_loadbalancer_id, port = 31380},
+    { loadbalancer = var.istio_oci_loadbalancer_id, port = 31390}
+  ]
 }

--- a/modules/worker/variables.tf
+++ b/modules/worker/variables.tf
@@ -57,6 +57,6 @@ variable "timezone" {
   type = string
 }
 
-variable "oci_loadbalancer_id" {
+variable "nginx_oci_loadbalancer_id" {
   type = string
 }

--- a/modules/worker/variables.tf
+++ b/modules/worker/variables.tf
@@ -60,3 +60,7 @@ variable "timezone" {
 variable "nginx_oci_loadbalancer_id" {
   type = string
 }
+
+variable "istio_oci_loadbalancer_id" {
+  type = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,3 +15,7 @@ output "ssh_to_master" {
   description = "ssh to primary master node"
   value       = "ssh -i ${var.ssh_private_key_path} -J opc@${module.base.bastion_public_ip} opc@${module.master.master_vip}"
 }
+
+output "Loadbalancer_addresses" {
+  value = "NGINX Loadbalancer: ${module.loadbalancer.pub_lb_ip} || Istio Loadbalancer: ${module.loadbalancer.istio_lb_ip}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,6 +16,6 @@ output "ssh_to_master" {
   value       = "ssh -i ${var.ssh_private_key_path} -J opc@${module.base.bastion_public_ip} opc@${module.master.master_vip}"
 }
 
-output "Loadbalancer_addresses" {
+output "loadbalancer_addresses" {
   value = "NGINX Loadbalancer: ${module.loadbalancer.pub_lb_ip} || Istio Loadbalancer: ${module.loadbalancer.istio_lb_ip}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,5 +17,5 @@ output "ssh_to_master" {
 }
 
 output "loadbalancer_addresses" {
-  value = "NGINX Loadbalancer: ${module.loadbalancer.pub_lb_ip} || Istio Loadbalancer: ${module.loadbalancer.istio_lb_ip}"
+  value = "NGINX Loadbalancer: ${module.loadbalancer.nginx_lb_ip} || Istio Loadbalancer: ${module.loadbalancer.istio_lb_ip}"
 }


### PR DESCRIPTION
Deploy a second load balancer that points at Istio NodePorts 
Outputs IP addresses of both loadbalancers, this could be extended to a new feature where DNS records are automatically modified.

Resolves #12  