### PR TITLE
Allow a user to choose if nginx is deployed as part of installation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,4 +148,5 @@ module "olcne" {
   helm_version = var.helm_version
 
   loadbalancer_ip_address = module.loadbalancer.pub_lb_ip
+  deploy_nginx_software = var.deploy_nginx_software
 }

--- a/modules/olcne/nginx.tf
+++ b/modules/olcne/nginx.tf
@@ -17,6 +17,7 @@ data "template_file" "nginx_patch" {
 }
 
 resource null_resource "install_nginxcontroller" {
+  count = var.deploy_nginx_software ? 1 : 0
 
   connection {
     host        = local.operator_private_ip

--- a/modules/olcne/variables.tf
+++ b/modules/olcne/variables.tf
@@ -102,7 +102,7 @@ variable "container_registry_urls" {
 }
 
 variable "deploy_nginx_software" {
-  description = "If true, deploy nginx Ingress"
+  description = "If true, deploy NGINX Ingress"
   type        = bool
   default     = true
 }

--- a/modules/olcne/variables.tf
+++ b/modules/olcne/variables.tf
@@ -102,7 +102,5 @@ variable "container_registry_urls" {
 }
 
 variable "deploy_nginx_software" {
-  description = "If true, deploy NGINX Ingress"
   type        = bool
-  default     = true
 }

--- a/modules/olcne/variables.tf
+++ b/modules/olcne/variables.tf
@@ -100,3 +100,9 @@ variable "container_registry_urls" {
   }
   type = map(string)
 }
+
+variable "deploy_nginx_software" {
+  description = "If true, deploy nginx Ingress"
+  type        = bool
+  default     = true
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -141,3 +141,5 @@ worker_shape = "VM.Standard.E2.2"
 worker_size = 3
 
 worker_timezone = "Australia/Sydney"
+
+deploy_nginx_software = true

--- a/variables.tf
+++ b/variables.tf
@@ -402,7 +402,7 @@ variable "tags" {
 }
 
 variable "deploy_nginx_software" {
-  description = "If true, deploy nginx Ingress"
+  description = "If true, deploy NGINX Ingress"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -400,3 +400,9 @@ variable "tags" {
   description = "Tags to apply to different resources."
   type        = map(any)
 }
+
+variable "deploy_nginx_software" {
+  description = "If true, deploy nginx Ingress"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
A user may want to deploy nginx-ingress as part of their own installation process. Support a boolean var of `deploy_nginx_software` which defaults to true and when negative create a OCI loadbalancer but skip the installation of nginx-ingress to Kubernetes

Tested with negative and positive value.
Signed-off-by: Mark Cram <mark.cram@oracle.com>